### PR TITLE
fix: scale fertilizer/irrigation costs with crop value

### DIFF
--- a/src/components/CropField.tsx
+++ b/src/components/CropField.tsx
@@ -32,7 +32,12 @@ const formatMoney = (n: number) => {
 
 const getCost = (baseCost: number, count: number, crop: string) => Math.floor(baseCost * Math.pow(getIncomeMultiplier(crop), count));
 
-const getUpgradeCost = (level: number) => Math.floor(100 * Math.pow(2, level));
+const getUpgradeCost = (level: number, crop: string) => {
+  const basePrice = SELL_PRICES[crop] || 1;
+  const wheatPrice = SELL_PRICES['wheat'] || 1;
+  const multiplier = basePrice / wheatPrice;
+  return Math.floor(100 * multiplier * Math.pow(2, level));
+};
 
 const formatCropName = (key: string) => {
   return key.replace(/([A-Z])/g, ' $1').replace(/^./, str => str.toUpperCase());
@@ -63,7 +68,7 @@ const CropField: React.FC = () => {
     const level = upgradeType === 'fertilizer' 
       ? (cropData.fertilizerLevel || 0) 
       : (cropData.irrigationLevel || 0);
-    const cost = getUpgradeCost(level);
+    const cost = getUpgradeCost(level, crop);
     
     if (state.resources.money >= cost) {
       dispatch({ type: 'UPGRADE_FARM', crop, upgradeType });
@@ -105,7 +110,7 @@ const CropField: React.FC = () => {
           };
           
           const nextUpgrade = getNextUpgrade();
-          const upgradeCost = getUpgradeCost(nextUpgrade.level);
+          const upgradeCost = getUpgradeCost(nextUpgrade.level, crop);
           
           const hasFarms = (data?.count ?? 0) > 0;
           
@@ -168,7 +173,7 @@ const CropField: React.FC = () => {
                     </div>
                     <button 
                       className="btn btn-primary" 
-                      style={{ fontSize: 10, padding: '6px 12px' }}
+                      style={{ fontSize: 10, padding: '6px 12px', opacity: state.resources.money < upgradeCost ? 0.5 : 1 }}
                       onClick={() => handleUpgrade(crop, nextUpgrade.type)}
                       disabled={state.resources.money < upgradeCost}
                     >


### PR DESCRIPTION
## Summary
- Fertilizer and Irrigation upgrade costs now scale proportionally to each crop's sell price
- Higher value crops have significantly more expensive upgrades (Corn 8x wheat, Potatoes 47x, etc.)
- Costs still increase 2x per upgrade level as before

## Changes
- Modified `getUpgradeCost` function in CropField.tsx to accept crop parameter
- Cost formula: `100 * (cropSellPrice / wheatSellPrice) * 2^level`

## Example Costs (level 0)
| Crop | Sell Price | Upgrade Cost |
|------|------------|--------------|
| Wheat | 1 | $100 |
| Corn | 8 | $800 |
| Potatoes | 47 | $4,700 |
| Sugarcane | 260 | $26,000 |
| Cotton | 2,000 | $200,000 |